### PR TITLE
Remove `await` qualifier from `tmpPath` example

### DIFF
--- a/API.md
+++ b/API.md
@@ -838,7 +838,7 @@ Generates a path to a tmp directory based on the current script name:
 
 ```js
 // Run from the "my-script.ts" script
-let tmpAsset = await tmpPath("result.txt")
+let tmpAsset = tmpPath("result.txt")
 // ~/.kenv/tmp/my-script/result.txt
 ```
 


### PR DESCRIPTION
The rest of the examples in these docs for `tmpPath` indicate that it does not return a Promise. Additionally, the function itself also currently does not return a Promise.

If there are some changes planned here to make this async, feel free to disregard this PR.

Otherwise, this is just some tidying up to remove the `await` and reduce any future confusion.